### PR TITLE
Bottom status bar background.

### DIFF
--- a/themes/Monokai Vibrant-color-theme.json
+++ b/themes/Monokai Vibrant-color-theme.json
@@ -564,7 +564,7 @@
     "scrollbarSlider.hoverBackground": "#5A637580",
     "sideBar.background": "#191B20",
     "sideBarSectionHeader.background": "#282c34",
-    "statusBar.background": "#16171D",
+    "statusBar.background": "#1D1F23",
     "statusBar.foreground": "#fff",
     "statusBarItem.hoverBackground": "#2c313a",
     "statusBar.noFolderBackground": "#21252B",

--- a/themes/Monokai Vibrant-color-theme.json
+++ b/themes/Monokai Vibrant-color-theme.json
@@ -551,8 +551,6 @@
     "editorSuggestWidget.selectedBackground": "#2c313a",
     "editorWidget.background": "#21252B",
     "input.background": "#1d1f23",
-    "notification.background": "#21252b",
-		// Lists
     "list.activeSelectionBackground": "#2c313a",
     "list.activeSelectionForeground": "#d7dae0",
     "list.focusBackground": "#383E4A",
@@ -560,24 +558,21 @@
     "list.highlightForeground": "#C5C5C5",
     "list.inactiveSelectionBackground": "#2c313a",
     "list.inactiveSelectionForeground": "#d7dae0",
-		// Scroll bars
+    "notification.background": "#21252b",
     "scrollbarSlider.background": "#4E566680",
     "scrollbarSlider.activeBackground": "#747D9180",
     "scrollbarSlider.hoverBackground": "#5A637580",
-		// Status bars
-    "sideBar.background": "#1D1F23",
+    "sideBar.background": "#191B20",
     "sideBarSectionHeader.background": "#282c34",
     "statusBar.background": "#16171D",
     "statusBar.foreground": "#fff",
     "statusBarItem.hoverBackground": "#2c313a",
     "statusBar.noFolderBackground": "#21252B",
     "statusBar.debuggingBackground": "#21252B",
-		// Tabs
     "tab.activeBackground": "#2c313a",
     "tab.border": "#181A1F",
 		"tab.activeBorderTop": "#007DD8",
     "tab.inactiveBackground": "#21252B",
-		// Titles
     "titleBar.activeBackground": "#282c34",
     "titleBar.activeForeground": "#9da5b4",
     "titleBar.inactiveBackground": "#282C34",

--- a/themes/Monokai Vibrant-color-theme.json
+++ b/themes/Monokai Vibrant-color-theme.json
@@ -551,6 +551,8 @@
     "editorSuggestWidget.selectedBackground": "#2c313a",
     "editorWidget.background": "#21252B",
     "input.background": "#1d1f23",
+    "notification.background": "#21252b",
+		// Lists
     "list.activeSelectionBackground": "#2c313a",
     "list.activeSelectionForeground": "#d7dae0",
     "list.focusBackground": "#383E4A",
@@ -558,21 +560,24 @@
     "list.highlightForeground": "#C5C5C5",
     "list.inactiveSelectionBackground": "#2c313a",
     "list.inactiveSelectionForeground": "#d7dae0",
-    "notification.background": "#21252b",
+		// Scroll bars
     "scrollbarSlider.background": "#4E566680",
     "scrollbarSlider.activeBackground": "#747D9180",
     "scrollbarSlider.hoverBackground": "#5A637580",
-    "sideBar.background": "#191B20",
+		// Status bars
+    "sideBar.background": "#1D1F23",
     "sideBarSectionHeader.background": "#282c34",
     "statusBar.background": "#16171D",
     "statusBar.foreground": "#fff",
     "statusBarItem.hoverBackground": "#2c313a",
     "statusBar.noFolderBackground": "#21252B",
     "statusBar.debuggingBackground": "#21252B",
+		// Tabs
     "tab.activeBackground": "#2c313a",
     "tab.border": "#181A1F",
 		"tab.activeBorderTop": "#007DD8",
     "tab.inactiveBackground": "#21252B",
+		// Titles
     "titleBar.activeBackground": "#282c34",
     "titleBar.activeForeground": "#9da5b4",
     "titleBar.inactiveBackground": "#282C34",


### PR DESCRIPTION
Hello!

I changed the background color of status bar and made it lighter. The current one is too dark and blends with backgrounds of terminal and editor. Very often I click on status bar instead of integrated terminal. 

Before the change:

![terminal-before](https://user-images.githubusercontent.com/26113686/140938420-e611f2f8-8cb8-4b2f-93b3-ebbb88c4caf5.png)

After:

![terminal-after](https://user-images.githubusercontent.com/26113686/140938480-96aee805-aaef-4ef2-bd28-734a7749b635.png)


