### PR TITLE
Options to choose theme with italic text or without

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
                 "label": "Monokai Vibrant",
                 "uiTheme": "vs-dark",
                 "path": "./themes/Monokai Vibrant-color-theme.json"
+            },
+            {
+                "label": "Monokai Vibrant (No Italics)",
+                "uiTheme": "vs-dark",
+                "path": "./themes/Monokai Vibrant No Italics-color-theme.json"
             }
         ]
     }

--- a/themes/Monokai Vibrant No Italics-color-theme.json
+++ b/themes/Monokai Vibrant No Italics-color-theme.json
@@ -1,6 +1,5 @@
 {
   "name": "Monokai Vibrant (No Italics)",
-  "semanticHighlighting": true,
   "type": "dark",
   "tokenColors": [
     {

--- a/themes/Monokai Vibrant No Italics-color-theme.json
+++ b/themes/Monokai Vibrant No Italics-color-theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Monokai Vibrant",
+  "name": "Monokai Vibrant (No Italics)",
   "semanticHighlighting": true,
   "type": "dark",
   "tokenColors": [
@@ -25,8 +25,7 @@
         "string.comment"
       ],
       "settings": {
-        "foreground": "#5c6370",
-        "fontStyle": "italic"
+        "foreground": "#5c6370"
       }
     },
     {
@@ -113,8 +112,7 @@
     "name": "Language Variable",
     "scope": "variable.language",
     "settings": {
-      "foreground": "#FF3F4F",
-      "fontStyle": "italic"
+      "foreground": "#FF3F4F"
     }
   },
   {
@@ -135,24 +133,21 @@
       "keyword.operator.constructor"
     ],
     "settings": {
-      "foreground": "#FF3F4F",
-      "fontStyle": "italic"
+      "foreground": "#FF3F4F"
     }
   },
   {
     "name": "Keyword Operator",
     "scope": "keyword.operator",
     "settings": {
-      "foreground": "#FF3F4F",
-      "fontStyle": "italic"
+      "foreground": "#FF3F4F"
     }
   },
   {
     "name": "Storage",
     "scope": "storage",
     "settings": {
-      "foreground": "#FF3F4F",
-      "fontStyle": "italic"
+      "foreground": "#FF3F4F"
     }
   },
   {
@@ -225,7 +220,6 @@
       "name": "Function argument",
       "scope": "variable.parameter",
       "settings": {
-        "fontStyle": "italic",
         "foreground": "#FF9700"
       }
     },
@@ -604,4 +598,5 @@
   "titleBar.inactiveBackground": "#282C34",
   "titleBar.inactiveForeground": "#6B717D"
 }
+
 }

--- a/themes/Monokai Vibrant No Italics-color-theme.json
+++ b/themes/Monokai Vibrant No Italics-color-theme.json
@@ -584,7 +584,7 @@
   "scrollbarSlider.hoverBackground": "#5A637580",
   "sideBar.background": "#191B20",
   "sideBarSectionHeader.background": "#282c34",
-  "statusBar.background": "#282C34",
+  "statusBar.background": "#16171D",
   "statusBar.foreground": "#fff",
   "statusBarItem.hoverBackground": "#2c313a",
   "statusBar.noFolderBackground": "#21252B",

--- a/themes/Monokai Vibrant-color-theme.json
+++ b/themes/Monokai Vibrant-color-theme.json
@@ -590,7 +590,7 @@
   "scrollbarSlider.hoverBackground": "#5A637580",
   "sideBar.background": "#191B20",
   "sideBarSectionHeader.background": "#282c34",
-  "statusBar.background": "#282C34",
+  "statusBar.background": "#16171D",
   "statusBar.foreground": "#fff",
   "statusBarItem.hoverBackground": "#2c313a",
   "statusBar.noFolderBackground": "#21252B",

--- a/themes/Monokai Vibrant-color-theme.json
+++ b/themes/Monokai Vibrant-color-theme.json
@@ -1,6 +1,5 @@
 {
   "name": "Monokai Vibrant",
-  "semanticHighlighting": true,
   "type": "dark",
   "tokenColors": [
     {


### PR DESCRIPTION
Dividing them into two separate ones. The first one (default) has same styles as before. The second one has no italic text for code (except markdown). Changes were made to packages.json for correct naming and order of themes.